### PR TITLE
Dashboard 1.81

### DIFF
--- a/imagevector/containers.yaml
+++ b/imagevector/containers.yaml
@@ -54,7 +54,7 @@ images:
   - name: gardener-dashboard
     sourceRepository: github.com/gardener/dashboard
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/dashboard
-    tag: "1.80.3"
+    tag: "1.81.0"
   - name: terminal-controller-manager
     sourceRepository: github.com/gardener/terminal-controller-manager
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/terminal-controller-manager

--- a/pkg/component/gardener/dashboard/dashboard_test.go
+++ b/pkg/component/gardener/dashboard/dashboard_test.go
@@ -357,7 +357,7 @@ frontend:
 									ImagePullPolicy: corev1.PullIfNotPresent,
 									Args: []string{
 										"--optimize-for-size",
-										"server.mjs",
+										"server.js",
 									},
 									Env: []corev1.EnvVar{
 										{

--- a/pkg/component/gardener/dashboard/deployment.go
+++ b/pkg/component/gardener/dashboard/deployment.go
@@ -109,7 +109,7 @@ func (g *gardenerDashboard) deployment(
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Args: []string{
 								"--optimize-for-size",
-								"server.mjs",
+								"server.js",
 							},
 							Env: []corev1.EnvVar{
 								{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind task

**What this PR does / why we need it**:
With [gardener/dashboard#2428](https://github.com/gardener/dashboard/pull/2428/files#diff-e6a1d92480cd16cd30155f4e1694f991d54adcc2ad6611395c7798452f71af72) (part of g/dashboard 1.81), `server.mjs` got renamed to `server.js`.

This change is necessary as part of our ongoing task to **migrate from CJS to ESM** in g/dashboard. The previous renaming from `server.js` to `server.mjs` was a **temporary measure** that is now being reverted as we complete the ESM migration process.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This change reverts https://github.com/gardener/gardener/pull/11977

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
